### PR TITLE
adding the feed id to the user-agent

### DIFF
--- a/app/workers/feed_refresher_fetcher.rb
+++ b/app/workers/feed_refresher_fetcher.rb
@@ -55,9 +55,9 @@ class FeedRefresherFetcher
       options[:if_none_match] = etag
     end
 
-    options[:user_agent] = "Feedbin"
+    options[:user_agent] = "Feedbin feed-id:#{feed_id}"
     unless subscribers.nil?
-      options[:user_agent] = "Feedbin - #{subscribers} subscribers"
+      options[:user_agent] = "Feedbin feed-id:#{feed_id} - #{subscribers} subscribers"
     end
 
     if push_callback


### PR DESCRIPTION
Ben, it's considered good practice to [include a feed-id](https://feed.press/support/tutorials/feedfetcher) in your user-agent when fetching a feed. 