### PR TITLE
Return value that's closer to its method name

### DIFF
--- a/app/throttle.rb
+++ b/app/throttle.rb
@@ -16,7 +16,7 @@ class Throttle
   end
 
   def downloaded_recently?
-    return nil if @last_download.nil?
+    return false if @last_download.nil?
     (Time.now.to_i - @last_download) < TIMEOUT
   end
 

--- a/app/throttle.rb
+++ b/app/throttle.rb
@@ -12,12 +12,12 @@ class Throttle
   end
 
   def throttled?
-    throttled_hosts.include?(host) && false == downloaded_recently?
+    throttled_hosts.include?(host) && downloaded_recently?
   end
 
   def downloaded_recently?
     return nil if @last_download.nil?
-    !((Time.now.to_i - @last_download) < TIMEOUT)
+    (Time.now.to_i - @last_download) < TIMEOUT
   end
 
   def time_remaining


### PR DESCRIPTION
Took me a while to realize why the original `Throttle#downloaded_recently?` returns `false` if it's downloaded recently. Also not sure why it uses `!` when `<` comparison already returns boolean...